### PR TITLE
deleted margin-bottom from Wrapper (desktopSmall)

### DIFF
--- a/src/common/Navigation/styled.js
+++ b/src/common/Navigation/styled.js
@@ -16,7 +16,6 @@ export const Wrapper = styled.div`
     @media(max-width: ${({ theme }) => theme.breakpoints.desktopSmall}px) { 
         flex-direction: column;
         padding: 16px;
-        margin-bottom: 24px;
     }
 `;
 


### PR DESCRIPTION
Usunęłam margin-bottom z Wrapper`a w nawigacji. Margines jest zachowany zgodnie z Figmą, ponieważ jest zapisany w Section.