### PR TITLE
renamed TileLarge to MovieTileLarge and TileSmall to MovieTileSmall

### DIFF
--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -1,6 +1,6 @@
 import { useMediaQuery } from "react-responsive";
 import { Section, SectionTitle } from "../../../common/Section";
-import { TileLarge, TileSmall } from "../../../common/Tile";
+import { MovieTileLarge, MovieTileSmall } from "../../../common/Tile";
 import { List, ListItem, StyledLink } from "./styled";
 import { toMovieDetails } from "../../../core/routes";
 import { StyledMain } from "../../../common/Main/styled";
@@ -16,7 +16,7 @@ export const MovieList = () => {
 					<StyledLink to={toMovieDetails()}>
 						<ListItem>
 							{isLargeScreen ? (
-								<TileLarge
+								<MovieTileLarge
 									ratingValue="8.1"
 									voteAmount="2000"
 									title="Mulan"
@@ -24,7 +24,7 @@ export const MovieList = () => {
 									tag="Action"
 								/>
 							) : (
-								<TileSmall
+								<MovieTileSmall
 									ratingValue="8.1"
 									voteAmount="2000"
 									title="Mulan"
@@ -36,6 +36,6 @@ export const MovieList = () => {
 					</StyledLink>
 				</List>
 			</Section>
-		</StyledMain >
+		</StyledMain>
 	);
 };


### PR DESCRIPTION
Zmieniłam nazwy z TileLarge na MovieTileLarge oraz TileSmall na MovieTileSmall, ponieważ te TileSmall i TileLarge były zbyt ogólne. Teraz wiadomo, że te kafelki dotyczą filmów.