### PR TITLE
changed h1 (Warning) and h2 (Info) to p

### DIFF
--- a/src/common/Error/styled.js
+++ b/src/common/Error/styled.js
@@ -19,7 +19,7 @@ export const StyledDanger = styled(DangerIconSVG)`
     }
 `;
 
-export const Warning = styled.h1`
+export const Warning = styled.p`
     text-align: center;
     margin: auto;
     font-weight: 600;
@@ -30,7 +30,7 @@ export const Warning = styled.h1`
         font-size: 26px;
     }
 `;
-export const Info = styled.h2`
+export const Info = styled.p`
     text-align: center;
     margin: auto;
     font-weight: 500;


### PR DESCRIPTION
Zmieniłam h1 i h2 na p, ponieważ na stronie powinna być tylko jedna h1, a u nas h1 jest w nawigacji ("Movies Browser"). Ponadto to są tylko informacje na temat błędu, więc myślę, że zwykłe info spokojnie może być w p.