### PR TITLE
added `useReplaceQueryParameter` for managing and updating query para…

### DIFF
--- a/src/common/Navigation/SearchBar/useQueryParameters.js
+++ b/src/common/Navigation/SearchBar/useQueryParameters.js
@@ -1,7 +1,41 @@
-import { useLocation } from "react-router-dom/cjs/react-router-dom";
+import { useLocation, useHistory } from "react-router-dom/cjs/react-router-dom";
 
 export const useQueryParameter = (target) => {
-    const location = useLocation();
+	const location = useLocation();
 
-    return (new URLSearchParams(location.search)).get(target);
+	return new URLSearchParams(location.search).get(target);
+};
+
+export const useReplaceQueryParameter = () => {
+	const location = useLocation();
+	const history = useHistory();
+
+	const searchParams = new URLSearchParams(location?.search || "");
+	const isMovies =
+		location.pathname.startsWith("/movies") ||
+		location.pathname.startsWith("/movieDetails");
+
+	return ({ key, value }) => {
+		if (value === undefined) {
+			searchParams.delete(key);
+		} else {
+			searchParams.set(key, value);
+		}
+
+		let newPath = isMovies ? "/movies/search" : "/people/search";
+
+		if (key === "query" && !value) {
+			newPath = isMovies ? "/movies" : "/people";
+		}
+
+		const currentPage = parseInt(searchParams.get("page")) || 1;
+		const currentQuery = searchParams.get("query");
+		let urlParams = `page=${currentPage}`;
+
+		if (currentQuery) {
+			urlParams += `&query=${currentQuery}`;
+		}
+
+		history.replace(`${newPath}?${urlParams}`);
+	};
 };


### PR DESCRIPTION
Dodałam useReplaceQueryParameter odpowiadający za zarządzanie i aktualizowanie parametrów zapytania w adresie URL. Jeśli wpiszemy coś w wyszukiwarkę to w adresie URL doda się "search?page=1&query=" i po znaku = będzie to co wpiszemy w wyszukiwarkę. Docelowo w zależności od tego czy będziemy na stronie z filmami czy z aktorami będą się wyświetlać kafelki z wyszukanymi wynikami począwszy od strony 1. Jeśli wpiszemy coś w wyszukiwarkę, a potem to usuniemy to adres URL wróci do strony głównej listy filmów lub aktorów.