### PR TITLE
changed "movieDetails" to "movies" and "peopleDetails" to "people"

### DIFF
--- a/src/core/routes.js
+++ b/src/core/routes.js
@@ -1,5 +1,5 @@
 export const toMovies = () => "/movies";
 export const toPeople = () => "/people";
 
-export const toMovieDetails = ({id} = {id: ":id"}) => `/movieDetails/${id}`;
-export const toPeopleDetails = ({id} = {id: ":id"}) => `/peopleDetails/${id}`;
+export const toMovieDetails = ({id} = {id: ":id"}) => `/movies/${id}`;
+export const toPeopleDetails = ({id} = {id: ":id"}) => `/people/${id}`;


### PR DESCRIPTION
Zmieniłam "movieDetails" na "movies" i "peopleDetails" na "people" aby rozwiązać problem obramowania dla przycisków nawigacji na stronach z detalami filmu lub szczegółami o aktorze.