### PR TITLE
Pagination adding functionality

### DIFF
--- a/src/API/getPopularMovies.js
+++ b/src/API/getPopularMovies.js
@@ -1,10 +1,10 @@
 import { APIbaseURL } from "./APIdata";
 import { AuthorizationAndLanguage } from "./APIdata";
 
-export const getPopularMovies = async () => {
+export const getPopularMovies = async (page) => {
     try {
         const response = await fetch(
-            `${APIbaseURL}movie/popular${AuthorizationAndLanguage}&page=1`
+            `${APIbaseURL}movie/popular${AuthorizationAndLanguage}&page=${page}`
         );
 
         if (!response.ok) {

--- a/src/API/getPopularPeople.js
+++ b/src/API/getPopularPeople.js
@@ -1,10 +1,10 @@
 import { APIbaseURL } from "./APIdata";
 import { AuthorizationAndLanguage } from "./APIdata";
 
-export const getPopularPeople = async () => {
+export const getPopularPeople = async (page) => {
     try {
         const response = await fetch(
-            `${APIbaseURL}person/popular${AuthorizationAndLanguage}&page=1`
+            `${APIbaseURL}person/popular${AuthorizationAndLanguage}&page=${page}`
         );
 
         if (!response.ok) {

--- a/src/API/pageParamName.js
+++ b/src/API/pageParamName.js
@@ -1,0 +1,1 @@
+export default "page";

--- a/src/common/Pagination/createPaginationActions.js
+++ b/src/common/Pagination/createPaginationActions.js
@@ -1,7 +1,7 @@
 export const paginationActions = () => {
 	const paginationReducers = {
-        pageNumberFromURL: (state, { payload: query }) => {
-            state.page = +query;
+        pageNumberFromURL: (state, { payload: pageParam }) => {
+            state.page = +pageParam;
             state.status = "loading";
         },
 	};

--- a/src/common/Pagination/createPaginationActions.js
+++ b/src/common/Pagination/createPaginationActions.js
@@ -1,0 +1,10 @@
+export const paginationActions = () => {
+	const paginationReducers = {
+        pageNumberFromURL: (state, { payload: query }) => {
+            state.page = +query;
+            state.status = "loading";
+        },
+	};
+
+	return { paginationReducers };
+};

--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -1,13 +1,41 @@
+import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
 import { BoldText, ButtonText, LeftVector, StyledButton, Text, TextContainer, Vector, Wrapper } from "./styled"
 
 export const Pagination = () => {
 
-    const page = 1;
+    const location = useLocation();
+    const history = useHistory();
+
+    const searchParams = new URLSearchParams(location.search);
+    const pageParam = searchParams.get("page");
+
+    const maxPage = 500;
+
+    const onIncrement = () => {
+        searchParams.set("page", +pageParam + 1);
+        history.push(`${location.pathname}?${searchParams.toString()}`);
+    };
+
+    const onDecrement = () => {
+        searchParams.set("page", +pageParam - 1);
+        history.push(`${location.pathname}?${searchParams.toString()}`);
+    };
+
+    const onToFirstPage = () => {
+        searchParams.set("page", 1);
+        history.push(`${location.pathname}?${searchParams.toString()}`);
+    };
+
+    const onToLastPage = () => {
+        searchParams.set("page", maxPage);
+        history.push(`${location.pathname}?${searchParams.toString()}`);
+    };
 
     return (
         <Wrapper>
             <StyledButton
-                disabled={page < 2}
+                onClick={onToFirstPage}
+                disabled={+pageParam < 2}
             >
                 <LeftVector />
                 <ButtonText>
@@ -15,7 +43,8 @@ export const Pagination = () => {
                 </ButtonText>
             </StyledButton>
             <StyledButton
-                disabled={page < 2}
+                onClick={onDecrement}
+                disabled={+pageParam < 2}
             >
                 <LeftVector />
                 <ButtonText>
@@ -29,14 +58,16 @@ export const Pagination = () => {
                 <BoldText>150</BoldText>
             </TextContainer>
             <StyledButton
-                disabled={page === 500}>
+                onClick={onIncrement}
+                disabled={+pageParam === maxPage}>
                 <ButtonText>
                     Next
                 </ButtonText>
                 <Vector />
             </StyledButton>
             <StyledButton
-                disabled={page === 500}>
+                onClick={onToLastPage}
+                disabled={+pageParam === maxPage}>
                 <ButtonText>
                     Last
                 </ButtonText>

--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -1,5 +1,6 @@
 import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
 import { BoldText, ButtonText, LeftVector, StyledButton, Text, TextContainer, Vector, Wrapper } from "./styled"
+import pageParamName from "../../API/pageParamName";
 
 export const Pagination = () => {
 
@@ -7,27 +8,27 @@ export const Pagination = () => {
     const history = useHistory();
 
     const searchParams = new URLSearchParams(location.search);
-    const pageParam = searchParams.get("page");
+    const pageParam = searchParams.get(pageParamName);
 
     const maxPage = 500;
 
     const onIncrement = () => {
-        searchParams.set("page", +pageParam + 1);
+        searchParams.set(pageParamName, +pageParam + 1);
         history.push(`${location.pathname}?${searchParams.toString()}`);
     };
 
     const onDecrement = () => {
-        searchParams.set("page", +pageParam - 1);
+        searchParams.set(pageParamName, +pageParam - 1);
         history.push(`${location.pathname}?${searchParams.toString()}`);
     };
 
     const onToFirstPage = () => {
-        searchParams.set("page", 1);
+        searchParams.set(pageParamName, 1);
         history.push(`${location.pathname}?${searchParams.toString()}`);
     };
 
     const onToLastPage = () => {
-        searchParams.set("page", maxPage);
+        searchParams.set(pageParamName, maxPage);
         history.push(`${location.pathname}?${searchParams.toString()}`);
     };
 

--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -1,5 +1,5 @@
 import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
-import { BoldText, ButtonText, LeftVector, StyledButton, Text, TextContainer, Vector, Wrapper } from "./styled"
+import { BoldText, ButtonText, LeftVector, MobileLeftVector, MobileVector, StyledButton, Text, TextContainer, Vector, Wrapper } from "./styled"
 import pageParamName from "../../API/pageParamName";
 
 export const Pagination = () => {
@@ -39,6 +39,7 @@ export const Pagination = () => {
                 disabled={+pageParam < 2}
             >
                 <LeftVector />
+                <MobileLeftVector />
                 <ButtonText>
                     First
                 </ButtonText>
@@ -73,6 +74,7 @@ export const Pagination = () => {
                     Last
                 </ButtonText>
                 <Vector />
+                <MobileVector />
             </StyledButton>
         </Wrapper>
     )

--- a/src/common/Pagination/index.js
+++ b/src/common/Pagination/index.js
@@ -54,9 +54,9 @@ export const Pagination = () => {
             </StyledButton>
             <TextContainer>
                 <Text>Page</Text>
-                <BoldText>1</BoldText>
+                <BoldText>{pageParam}</BoldText>
                 <Text>of</Text>
-                <BoldText>150</BoldText>
+                <BoldText>{maxPage}</BoldText>
             </TextContainer>
             <StyledButton
                 onClick={onIncrement}

--- a/src/common/Pagination/styled.js
+++ b/src/common/Pagination/styled.js
@@ -77,3 +77,17 @@ export const Vector = styled(VectorSVG)``;
 export const LeftVector = styled(Vector)`
 	transform: rotate(180deg);
 `;
+
+export const MobileVector = styled(Vector)`
+	@media (min-width: ${({theme}) => theme.breakpoints.mobileLarge}px) {
+		display: none;
+	}
+`;
+
+export const MobileLeftVector = styled(LeftVector)`
+	@media (min-width: ${({theme}) => theme.breakpoints.mobileLarge}px) {
+		display: none;
+	}
+`;
+
+

--- a/src/common/Pagination/useURLParams.js
+++ b/src/common/Pagination/useURLParams.js
@@ -1,0 +1,18 @@
+import { useDispatch } from "react-redux"
+import { pageNumberFromURL as moviePageNumberFromURL } from "../../features/movies/MovieList/movieListSlice"
+import { pageNumberFromURL as peoplePageNumberFromURL } from "../../features/people/PeopleList/peopleListSlice";
+
+export const useUpdatePageFromURL = () => {
+
+    const dispatch = useDispatch();
+    return ({ key, value }) => {
+        
+        if (key === "movies") {
+            dispatch(moviePageNumberFromURL(value))
+        }
+
+        if( key === "people") {
+            dispatch(peoplePageNumberFromURL(value))
+        }
+    }
+};

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -26,13 +26,18 @@ export const MovieList = () => {
 
 	const pageParam = searchParams.get("page");
 
-
 	const movies = useSelector(selectMovieList);
 	const status = useSelector(selectMovieListStatus);
 
 	useEffect(() => {
 		dispatch(setStatus());
-	}, []);
+
+		if (pageParam === null) {
+			searchParams.set("page", 1);
+			history.push(`${location.pathname}?${searchParams.toString()}`);
+		}
+
+	}, [location]);
 
 	switch (status) {
 		case "loading":

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -7,6 +7,7 @@ import { toMovieDetails } from "../../../core/routes";
 import { StyledMain as Main } from "../../../common/Main/styled";
 import { useDispatch, useSelector } from "react-redux";
 import {
+	pageNumberFromURL,
 	selectMovieList,
 	selectMovieListStatus,
 	setStatus,
@@ -36,6 +37,8 @@ export const MovieList = () => {
 			searchParams.set("page", 1);
 			history.push(`${location.pathname}?${searchParams.toString()}`);
 		}
+
+		dispatch(pageNumberFromURL(pageParam));
 
 	}, [location]);
 

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -14,11 +14,19 @@ import {
 import { useEffect } from "react";
 import { Loading } from "../../../common/Loading";
 import { Error } from "../../../common/Error";
+import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
 
 export const MovieList = () => {
 	const isLargeScreen = useMediaQuery({ query: "(min-width: 993px)" });
 
 	const dispatch = useDispatch();
+	const location = useLocation();
+	const history = useHistory();
+	const searchParams = new URLSearchParams(location.search);
+
+	const pageParam = searchParams.get("page");
+
+
 	const movies = useSelector(selectMovieList);
 	const status = useSelector(selectMovieListStatus);
 
@@ -48,7 +56,7 @@ export const MovieList = () => {
 									poster,
 								}) => (
 									<ListItem key={id}>
-										<StyledLink to={toMovieDetails({id:id})}>
+										<StyledLink to={toMovieDetails({ id: id })}>
 											{isLargeScreen ? (
 												<MovieTileLarge
 													poster={poster}

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -17,29 +17,34 @@ import { Loading } from "../../../common/Loading";
 import { Error } from "../../../common/Error";
 import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
 import pageParamName from "../../../API/pageParamName";
+import { useUpdatePageFromURL } from "../../../common/Pagination/useURLParams";
 
 export const MovieList = () => {
 	const isLargeScreen = useMediaQuery({ query: "(min-width: 993px)" });
 
-	const dispatch = useDispatch();
 	const location = useLocation();
 	const history = useHistory();
 	const searchParams = new URLSearchParams(location.search);
 
-	const pageParam = searchParams.get(pageParamName);
-
 	const movies = useSelector(selectMovieList);
 	const status = useSelector(selectMovieListStatus);
 
+	const updatePageFromURL = useUpdatePageFromURL()
+
+	const pageParam = searchParams.get(pageParamName);
+	const URLparams = {
+		key: "movies",
+		value: pageParam,
+	};
+
 	useEffect(() => {
-		dispatch(setStatus());
 
 		if (pageParam === null) {
 			searchParams.set(pageParamName, 1);
 			history.push(`${location.pathname}?${searchParams.toString()}`);
 		}
 
-		dispatch(pageNumberFromURL(pageParam));
+		updatePageFromURL(URLparams);
 
 	}, [location]);
 

--- a/src/features/movies/MovieList/index.js
+++ b/src/features/movies/MovieList/index.js
@@ -16,6 +16,7 @@ import { useEffect } from "react";
 import { Loading } from "../../../common/Loading";
 import { Error } from "../../../common/Error";
 import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
+import pageParamName from "../../../API/pageParamName";
 
 export const MovieList = () => {
 	const isLargeScreen = useMediaQuery({ query: "(min-width: 993px)" });
@@ -25,7 +26,7 @@ export const MovieList = () => {
 	const history = useHistory();
 	const searchParams = new URLSearchParams(location.search);
 
-	const pageParam = searchParams.get("page");
+	const pageParam = searchParams.get(pageParamName);
 
 	const movies = useSelector(selectMovieList);
 	const status = useSelector(selectMovieListStatus);
@@ -34,7 +35,7 @@ export const MovieList = () => {
 		dispatch(setStatus());
 
 		if (pageParam === null) {
-			searchParams.set("page", 1);
+			searchParams.set(pageParamName, 1);
 			history.push(`${location.pathname}?${searchParams.toString()}`);
 		}
 

--- a/src/features/movies/MovieList/movieListSaga.js
+++ b/src/features/movies/MovieList/movieListSaga.js
@@ -1,14 +1,15 @@
-import { all, call, delay, put, takeEvery } from "redux-saga/effects";
+import { all, call, delay, put, select, takeEvery } from "redux-saga/effects";
 import { getPopularMovies } from "../../../API/getPopularMovies";
-import { setError, setGenres, setMovieList, setStatus } from "./movieListSlice";
+import { pageNumberFromURL, selectMovieListPage, setError, setGenres, setMovieList, setStatus } from "./movieListSlice";
 import { getGenres } from "../../../API/getGenres";
 import { processMovieListData } from "../../../API/processAPIData";
 
 function* fetchMovieHandler() {
     try {
         yield delay(1000);
+        const page = yield select(selectMovieListPage)
         const [movieListData, genreList] = yield all([
-            call(getPopularMovies),
+            call(getPopularMovies, page),
             call(getGenres)
         ]);
         const processedMovieList = yield call(processMovieListData, movieListData, genreList);
@@ -22,5 +23,5 @@ function* fetchMovieHandler() {
 }
 
 export function* movieListSaga() {
-    yield takeEvery(setStatus.type, fetchMovieHandler);
+    yield takeEvery(pageNumberFromURL, fetchMovieHandler);
 }

--- a/src/features/movies/MovieList/movieListSlice.js
+++ b/src/features/movies/MovieList/movieListSlice.js
@@ -1,13 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { paginationActions } from '../../../common/Pagination/createPaginationActions';
+
+const { paginationReducers } = paginationActions("movieListSLice");
 
 const movieListSlice = createSlice({
     name: "movieList",
     initialState: {
+        page: undefined,
         movies: [],
         genres: [],
         status: "initial",
     },
     reducers: {
+        ...paginationReducers,
         setStatus: (state) => {
             state.status = "loading";
         },
@@ -26,6 +31,7 @@ const movieListSlice = createSlice({
 });
 
 export const {
+    pageNumberFromURL,
     setMovieList,
     setStatus,
     setGenres,
@@ -35,6 +41,7 @@ export const {
 const selectMovieListState = (state) => state.movieList;
 
 export const selectMovieListStatus = (state) => selectMovieListState(state).status;
+export const selectMovieListPage = (state) => selectMovieListState(state).page;
 export const selectMovieList = (state) => selectMovieListState(state).movies;
 
 export const selectGenres = (state) => selectMovieListState(state).genres;

--- a/src/features/people/PeopleList/index.js
+++ b/src/features/people/PeopleList/index.js
@@ -13,15 +13,37 @@ import {
 } from "./peopleListSlice";
 import { Loading } from "../../../common/Loading";
 import { Error } from "../../../common/Error";
+import pageParamName from "../../../API/pageParamName";
+import { useUpdatePageFromURL } from "../../../common/Pagination/useURLParams";
+import { useHistory, useLocation } from "react-router-dom/cjs/react-router-dom";
 
 export const PeopleList = () => {
 	const dispatch = useDispatch();
+	const location = useLocation();
+	const history = useHistory();
+	const searchParams = new URLSearchParams(location.search);
+
 	const people = useSelector(selectPeopleList);
 	const status = useSelector(selectPeopleListStatus);
 
+	const updatePageFromURL = useUpdatePageFromURL()
+
+	const pageParam = searchParams.get(pageParamName);
+	const URLparams = {
+		key: "people",
+		value: pageParam,
+	};
+
 	useEffect(() => {
-		dispatch(setStatus());
-	}, [dispatch]);
+
+		if (pageParam === null) {
+			searchParams.set(pageParamName, 1);
+			history.push(`${location.pathname}?${searchParams.toString()}`);
+		}
+
+		updatePageFromURL(URLparams);
+
+	}, [location]);
 
 	switch (status) {
 		case "loading":

--- a/src/features/people/PeopleList/peopleListSaga.js
+++ b/src/features/people/PeopleList/peopleListSaga.js
@@ -1,11 +1,12 @@
-import { call, delay, put, takeEvery } from "redux-saga/effects";
+import { call, delay, put, select, takeEvery } from "redux-saga/effects";
 import { getPopularPeople } from "../../../API/getPopularPeople";
-import { setError, setPeopleList, setStatus } from "./peopleListSlice";
+import { pageNumberFromURL, selectPeopleListPage, setError, setPeopleList, setStatus } from "./peopleListSlice";
 
 function* fetchPeopleHandler() {
     try {
         yield delay(1000);
-        const peopleListData = yield call(getPopularPeople);
+        const page = yield select(selectPeopleListPage);
+        const peopleListData = yield call(getPopularPeople, page);
         yield put(setPeopleList(peopleListData));
     } catch (error) {
         yield put(setError());
@@ -13,5 +14,5 @@ function* fetchPeopleHandler() {
 }
 
 export function* peopleListSaga() {
-    yield takeEvery(setStatus.type, fetchPeopleHandler);
+    yield takeEvery(pageNumberFromURL, fetchPeopleHandler);
 }

--- a/src/features/people/PeopleList/peopleListSlice.js
+++ b/src/features/people/PeopleList/peopleListSlice.js
@@ -1,12 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { paginationActions } from '../../../common/Pagination/createPaginationActions';
+
+const { paginationReducers } = paginationActions("peopleListSLice");
+
 const peopleListSlice = createSlice({
     name: "peopleList",
     initialState: {
+        page: undefined,
         people: [],
         status: "initial",
     },
     reducers: {
+        ...paginationReducers,
         setStatus: (state) => {
             state.status = "loading";
         },
@@ -21,6 +27,7 @@ const peopleListSlice = createSlice({
 });
 
 export const {
+    pageNumberFromURL,
     setPeopleList,
     setStatus,
     setError,
@@ -29,6 +36,7 @@ export const {
 const selectPeopleListState = (state) => state.peopleList;
 
 export const selectPeopleListStatus = (state) => selectPeopleListState(state).status;
+export const selectPeopleListPage = (state) => selectPeopleListState(state).page;
 export const selectPeopleList = (state) => selectPeopleListState(state).people;
 
 export default peopleListSlice.reducer;


### PR DESCRIPTION
Dodałem funkcjonalność paginacji, dla objaśnienie opisze w kilku krokach jak to zrobiłem:
W useEffect na stronach MovieList i PeopleList zamiast  wywoływać akcję setStatus, która była triggerem dla odpalania Sag:

Dodałem, że jeśli nie wartości parametru page w URL (a tak jest po przejściu na jakąś stronę), to wpisuję do URL parametr page z wartością 1 i odpalam funkcję updatePageFromURL, która w zależności czy podaję klucz "movies" czy "people" dispatchuje akcję pageNumberFromURL, a ta ustawia wartość page w odpowiednim Slice Movies lub People na taką jaka jest w parametrze page w URL, wtedy odpala się Saga, która wywołuje funkcję pobierającą dane z API z przekazaną wartością page.

Ten useEffect odpala się zawsze, jeśli zostaje zmieniony adres URL, dlatego na kliknięcie w przyciski paginacji odpalane są funkcję, które zmieniają wartość parametru page  w URL i wtedy schemat za każdym razem się powtarza, (poza tym że page w URL już jest więc pomijany jest ten warunkowy fragment ustawiania wartości parametru page w URL na 1, bo to już nie jest potrzebne), potrzebne jest to tylko po przejściu na jakąś stronę, gdy tego parametru w ogóle nie ma, a chcemy by odrazu pobrała się nam pierwsza strona.
