### PR TITLE
added fallback for missing birthday and place of birth values

### DIFF
--- a/src/features/people/PeopleDetails/index.js
+++ b/src/features/people/PeopleDetails/index.js
@@ -26,8 +26,12 @@ export const PeopleDetails = () => {
 				<PeopleDetailsTile
 					picturePersonDetails={picturePersonDetails}
 					name={person.name}
-					date={person.birthday}
-					place={person.place_of_birth}
+					date={
+						person.birthday
+							? new Date(person.birthday).toLocaleDateString()
+							: "Unknown"
+					}
+					place={person.place_of_birth ? person.place_of_birth : "Unknown"}
 					description={person.biography}
 				/>
 			</Section>


### PR DESCRIPTION
If a person's data does not contain a date or place of birth, the annotation "Unknown" will be inserted. Date format changed from yyyy-mm-dd to dd.mm.yyyy.