### PR TITLE
removed `Section` component from `Loading` component

### DIFF
--- a/src/common/Loading/index.js
+++ b/src/common/Loading/index.js
@@ -1,10 +1,7 @@
-import { Section } from "../Section";
 import { BoxForSpinner, Spinner } from "./styled";
 
 export const Loading = () => (
-	<Section>
 		<BoxForSpinner>
 			<Spinner />
 		</BoxForSpinner>
-	</Section>
 );


### PR DESCRIPTION
Removed `Section` component from `Loading` component:
- updated `Loading` component to remove unnecessary use of `Section` component
- now `BoxForSpinner` is a direct container for `Spinner`, simplifying the component structure