### PR TITLE
Common/tile

### DIFF
--- a/src/common/Tile/index.js
+++ b/src/common/Tile/index.js
@@ -26,8 +26,10 @@ import {
 	MovieListContent,
 	PersonImage,
 	NoPosterPhoto,
-	ImageContainer,
 	MovieImage,
+	NoPhotoBox,
+	NoMoviePhotoBox,
+	NoPersonPhotoBox,
 } from "./styled";
 import { Rating } from "../Rating";
 import { posterURL, profileURL } from "../../API/APIdata";
@@ -47,7 +49,9 @@ export const MovieTile = ({
 				{poster ? (
 					<Image src={`${posterURL}${poster}`} alt="" />
 				) : (
-					<NoPosterPhoto />
+					<NoPhotoBox>
+						<NoPosterPhoto />
+					</NoPhotoBox>
 				)}
 			</MovieImageContainer>
 			<MovieListContent>
@@ -69,7 +73,9 @@ export const PeopleTile = ({ name, character, role, profilePath }) => (
 			{profilePath ? (
 				<Image src={`${profileURL}${profilePath}`} alt="" />
 			) : (
-				<NoProfilePhoto />
+				<NoPhotoBox>
+					<NoProfilePhoto />
+				</NoPhotoBox>
 			)}
 		</PeopleImageContainer>
 		<ActorProfile>
@@ -101,9 +107,9 @@ export const MovieDetailsTile = ({
 			{poster ? (
 				<MovieImage src={poster} alt="" />
 			) : (
-				<ImageContainer>
+				<NoMoviePhotoBox>
 					<NoPosterPhoto />
-				</ImageContainer>
+				</NoMoviePhotoBox>
 			)}
 			<ContentInDetailsTile>
 				<TitleInDetailsTile>{title}</TitleInDetailsTile>
@@ -147,7 +153,13 @@ export const PeopleDetailsTile = ({
 
 	return (
 		<StyledDetailsTile>
-			<PersonImage src={picturePersonDetails} alt="" />
+			{picturePersonDetails ? (
+				<PersonImage src={picturePersonDetails} alt="" />
+			) : (
+				<NoPersonPhotoBox>
+					<NoPosterPhoto />
+				</NoPersonPhotoBox>
+			)}
 			<ContentInDetailsTile>
 				<TitleInDetailsTile>{name}</TitleInDetailsTile>
 				<BoxOnDetails>

--- a/src/common/Tile/styled.js
+++ b/src/common/Tile/styled.js
@@ -64,8 +64,15 @@ export const ImageContainer = styled.div`
 	align-items: center;
 	border-radius: 5px;
 	overflow: hidden;
+`;
+
+export const NoPhotoBox = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	background-color: gray;
-	color: white;
 `;
 
 // styles for MovieTile
@@ -155,7 +162,7 @@ export const NoPosterPhoto = styled(NoPosterPhotoSVG)`
 	width: 72px;
 	height: 72px;
 
-	@media (max-width: ${({ theme }) => theme.breakpoints.mobileSmall}px) {
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobileLarge}px) {
 		width: 48px;
 		height: 48px;
 	}
@@ -249,6 +256,40 @@ export const StyledDetailsTile = styled(Tile)`
 		display: grid;
 		grid-template-columns: auto 1fr;
 		padding: 16px;
+	}
+`;
+
+export const NoMoviePhotoBox = styled(NoPhotoBox)`
+	width: 312px;
+	height: 468px;
+	margin: 0px 40px 20px 0px;
+	border-radius: 5px;
+	float: left;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobileLarge}px) {
+		width: 114px;
+		height: 169px;
+		margin: 0px 16px 16px 0px;
+	}
+`;
+
+export const NoPersonPhotoBox = styled(NoPhotoBox)`
+	width: 399px;
+	height: 598px;
+	margin: 0px 40px 20px 0px;
+	border-radius: 5px;
+	float: left;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.desktopSmall}px) {
+		width: 300px;
+		height: 450px;
+		margin: 0px 30px 14px 0px;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.mobileLarge}px) {
+		width: 116px;
+		height: 174px;
+		margin: 0px 16px 16px 0px;
 	}
 `;
 


### PR DESCRIPTION
Added NoPhotoBox, NoMoviePhotoBox, NoPersonPhotoBox and styles for them. Thanks to these boxes, the lack of a photo on tiles with details is displayed correctly and the problem with a visible gray bar on photos in the tile list at low resolutions is solved.